### PR TITLE
feat: Use WampPayloadValue instead of WampArg in payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.2.0
+
+* [Breaking change] Changed the type of functions payload arguments to handle
+  any JSON-serializable value (msgpack is also working, but we currently use
+  `serde_json::Value`, which has its limits)
+
+## 0.1.1
+
+* Migrated to GitHub

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wamp_async"
 description = "An asynchronous WAMP implementation"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["ElasT0ny <elast0ny00@gmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -9,38 +9,41 @@ An asynchronous [WAMP](https://wamp-proto.org/) client implementation written in
 
 For usage examples, see :
 - [Publisher/Subscriber](https://github.com/elast0ny/wamp_async/blob/master/examples/pubsub.rs)
-```rust
-// Publish event with no arguments and with acknowledgment
-let ack_id = client.publish("peer.heartbeat", None, None, true).await?;
-println!("Ack id {}", ack_id.unwrap());
-```
-```rust
-// Register for events
-let (_sub_id, mut event_queue) = client.subscribe("peer.heartbeat").await?;
-// Wait for the next event
-match event_queue.recv().await {
-    Some((_pub_id, args, kwargs)) => println!("Event(args: {:?}, kwargs: {:?})", args, kwargs),
-    None => println!("Event queue closed"),
-};
-```
-- RPC [caller](https://github.com/elast0ny/wamp_async/blob/master/examples/rpc_caller.rs) & [callee](https://github.com/elast0ny/wamp_async/blob/master/examples/rpc_callee.rs)
-```rust
-// Call endpoint with one argument
-let (args, kwargs) = client.call("peer.echo", Some(vec![Arg::Integer(12)]), None).await?;
-println!("RPC returned {:?} {:?}", args, kwargs);
-```
-```rust
-// Declare your RPC function
-async fn rpc_echo(args: WampArgs, kwargs: WampKwArgs) -> Result<(WampArgs, WampKwArgs), WampError> {
-    println!("peer.echo {:?} {:?}", args, kwargs);
-    Ok((args, kwargs))
-}
 
-// Register the function
-let rpc_id = client.register("peer.echo", rpc_echo).await?;
-```
+    ```rust
+    // Publish event with no arguments and with acknowledgment
+    let ack_id = client.publish("peer.heartbeat", None, None, true).await?;
+    println!("Ack id {}", ack_id.unwrap());
+    ```
+    ```rust
+    // Register for events
+    let (_sub_id, mut event_queue) = client.subscribe("peer.heartbeat").await?;
+    // Wait for the next event
+    match event_queue.recv().await {
+        Some((_pub_id, args, kwargs)) => println!("Event(args: {:?}, kwargs: {:?})", args, kwargs),
+        None => println!("Event queue closed"),
+    };
+    ```
+- RPC [caller](https://github.com/elast0ny/wamp_async/blob/master/examples/rpc_caller.rs) & [callee](https://github.com/elast0ny/wamp_async/blob/master/examples/rpc_callee.rs)
+
+    ```rust
+    // Call endpoint with one argument
+    let (args, kwargs) = client.call("peer.echo", Some(vec![12.into()]), None).await?;
+    println!("RPC returned {:?} {:?}", args, kwargs);
+    ```
+    ```rust
+    // Declare your RPC function
+    async fn rpc_echo(args: Option<WampArgs>, kwargs: Option<WampKwArgs>) -> Result<(Option<WampArgs>, Option<WampKwArgs>), WampError> {
+        println!("peer.echo {:?} {:?}", args, kwargs);
+        Ok((args, kwargs))
+    }
+
+    // Register the function
+    let rpc_id = client.register("peer.echo", rpc_echo).await?;
+    ```
 
 ## Features
+
 | Feature | Desciption | Status |
 |---------|------------|--------|
 |Websocket| Use [websocket](https://en.wikipedia.org/wiki/WebSocket) as the transport | ✔ |
@@ -49,7 +52,9 @@ let rpc_id = client.register("peer.echo", rpc_echo).await?;
 | Secure RawSocket | RawSocket with TLS | ✔ |
 |MsgPack| Use [MessagePack](https://en.wikipedia.org/wiki/MessagePack) for message serialization | ✔ |
 |JSON | Uses [JSON](https://en.wikipedia.org/wiki/JSON#Example) for message serialization | ✔ |
+
 ### Client
+
 #### Basic profile :
 
 | Feature | Desciption | Status |

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Connect to the server
     let (mut client, (evt_loop, _rpc_evt_queue)) = Client::connect(
-        "tcps://localhost:8081",
+        "wss://localhost:8080/ws",
         Some(ClientConfig::default().set_ssl_verify(false)),
     )
     .await?;

--- a/examples/rpc_callee.rs
+++ b/examples/rpc_callee.rs
@@ -8,11 +8,14 @@ use wamp_async::{
 };
 
 lazy_static! {
-    static ref RPC_CALL_COUNT: AtomicU64 = { AtomicU64::new(0) };
+    static ref RPC_CALL_COUNT: AtomicU64 = AtomicU64::new(0);
 }
 
 // Simply return the rpc arguments
-async fn echo(args: WampArgs, kwargs: WampKwArgs) -> Result<(WampArgs, WampKwArgs), WampError> {
+async fn echo(
+    args: Option<WampArgs>,
+    kwargs: Option<WampKwArgs>,
+) -> Result<(Option<WampArgs>, Option<WampKwArgs>), WampError> {
     println!("peer.echo {:?} {:?}", args, kwargs);
     let _ = RPC_CALL_COUNT.fetch_add(1, Ordering::Relaxed);
     Ok((args, kwargs))
@@ -60,10 +63,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Register our function to a uri
     let rpc_id = client.register("peer.echo", echo).await?;
 
-    println!("Waiting for 'peer.echo' to be called at least 5 times");
+    println!("Waiting for 'peer.echo' to be called at least 4 times");
     loop {
         let call_num = RPC_CALL_COUNT.load(Ordering::Relaxed);
-        if call_num >= 5 || !client.is_connected() {
+        if call_num >= 4 || !client.is_connected() {
             break;
         }
         tokio::time::delay_for(std::time::Duration::from_secs(1)).await;

--- a/examples/rpc_caller.rs
+++ b/examples/rpc_caller.rs
@@ -1,5 +1,15 @@
 use std::error::Error;
-use wamp_async::{Arg, Client, ClientConfig, ClientRole, SerializerType};
+
+use serde::{Deserialize, Serialize};
+
+use wamp_async::{
+    try_into_any_value, Client, ClientConfig, ClientRole, SerializerType, WampKwArgs,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct MyStruct {
+    field1: String,
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -26,27 +36,49 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("Joining realm");
     client.join_realm("realm1").await?;
 
-    let mut num_calls: u64 = 0;
-    loop {
-        println!("Calling 'peer.echo'");
+    let my_struct = MyStruct {
+        field1: "value1".to_string(),
+    };
+    let positional_args = vec![
+        12i64.into(),
+        13.3f64.into(),
+        u32::MAX.into(),
+        i32::MIN.into(),
+        u64::MAX.into(),
+        "str".into(),
+        vec![-1].into(),
+        try_into_any_value(&my_struct).unwrap(),
+    ];
+    let mut keyword_args = WampKwArgs::new();
+    keyword_args.insert("key".to_string(), try_into_any_value(&my_struct).unwrap());
+
+    for (send_args, send_kwargs) in vec![
+        (None, None),
+        (Some(positional_args.clone()), None),
+        (None, Some(keyword_args.clone())),
+        (Some(positional_args.clone()), Some(keyword_args.clone())),
+    ] {
+        let send_args_copy = send_args.clone();
+        let send_kwargs_copy = send_kwargs.clone();
 
         // Call the RPC endpoint and wait for the result
-        match client
-            .call("peer.echo", Some(vec![Arg::Integer(12)]), None)
-            .await
-        {
-            Ok((res_args, res_kwargs)) => println!("\tGot {:?} {:?}", res_args, res_kwargs),
+        println!(
+            "Calling 'peer.echo' with {:?} and {:?}",
+            send_args, send_kwargs
+        );
+        match client.call("peer.echo", send_args, send_kwargs).await {
+            Ok((res_args, res_kwargs)) => {
+                println!("\tGot {:?} {:?}", res_args, res_kwargs);
+                assert_eq!(res_args, send_args_copy);
+                assert_eq!(res_kwargs, send_kwargs_copy);
+            }
             Err(e) => {
                 println!("Error calling ({:?})", e);
                 break;
             }
         };
 
-        // Stop after calling 5 times
-        num_calls += 1;
-        if num_calls >= 5 {
-            break;
-        }
+        println!();
         tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -366,8 +366,8 @@ impl Client {
     pub async fn publish<T: AsRef<str>>(
         &self,
         topic: T,
-        arguments: WampArgs,
-        arguments_kw: WampKwArgs,
+        arguments: Option<WampArgs>,
+        arguments_kw: Option<WampKwArgs>,
         acknowledge: bool,
     ) -> Result<Option<WampId>, WampError> {
         let mut options = WampDict::new();
@@ -414,8 +414,10 @@ impl Client {
     pub async fn register<T, F, Fut>(&self, uri: T, func_ptr: F) -> Result<WampId, WampError>
     where
         T: AsRef<str>,
-        F: Fn(WampArgs, WampKwArgs) -> Fut + Send + Sync + 'static,
-        Fut: Future<Output = Result<(WampArgs, WampKwArgs), WampError>> + Send + 'static,
+        F: Fn(Option<WampArgs>, Option<WampKwArgs>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<(Option<WampArgs>, Option<WampKwArgs>), WampError>>
+            + Send
+            + 'static,
     {
         // Send the request
         let (res, result) = oneshot::channel();
@@ -473,9 +475,9 @@ impl Client {
     pub async fn call<T: AsRef<str>>(
         &self,
         uri: T,
-        arguments: WampArgs,
-        arguments_kw: WampKwArgs,
-    ) -> Result<(WampArgs, WampKwArgs), WampError> {
+        arguments: Option<WampArgs>,
+        arguments_kw: Option<WampKwArgs>,
+    ) -> Result<(Option<WampArgs>, Option<WampKwArgs>), WampError> {
         // Send the request
         let (res, result) = oneshot::channel();
         if let Err(e) = self.ctl_channel.send(Request::Call {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -33,9 +33,9 @@ pub type JoinResult = Sender<
     >,
 >;
 pub type SubscriptionQueue = UnboundedReceiver<(
-    WampId,   // Publish event ID
-    WampArgs, // Publish args
-    WampKwArgs,
+    WampId,           // Publish event ID
+    Option<WampArgs>, // Publish args
+    Option<WampKwArgs>,
 )>; // publish kwargs
 pub type PendingSubResult = Sender<
     Result<
@@ -55,8 +55,8 @@ pub type PendingRegisterResult = Sender<
 pub type PendingCallResult = Sender<
     Result<
         (
-            WampArgs,   // Return args
-            WampKwArgs, // Return kwargs
+            Option<WampArgs>,   // Return args
+            Option<WampKwArgs>, // Return kwargs
         ),
         WampError,
     >,
@@ -82,7 +82,7 @@ pub struct Core {
     /// Pending subscription requests sent to the server
     pending_sub: HashMap<WampId, PendingSubResult>,
     /// Current subscriptions
-    subscriptions: HashMap<WampId, UnboundedSender<(WampId, WampArgs, WampKwArgs)>>,
+    subscriptions: HashMap<WampId, UnboundedSender<(WampId, Option<WampArgs>, Option<WampKwArgs>)>>,
 
     /// Pending RPC registration requests sent to the server
     pending_register: HashMap<WampId, (RpcFunc, PendingRegisterResult)>,

--- a/src/core/recv.rs
+++ b/src/core/recv.rs
@@ -63,8 +63,8 @@ pub async fn event(
     subscription: WampId,
     publication: WampId,
     _details: WampDict,
-    arguments: Option<WampList>,
-    arguments_kw: Option<WampDict>,
+    arguments: Option<WampArgs>,
+    arguments_kw: Option<WampKwArgs>,
 ) -> Status {
     let evt_queue = match core.subscriptions.get(&subscription) {
         Some(e) => e,
@@ -153,8 +153,8 @@ pub async fn invocation(
     request: WampId,
     registration: WampId,
     _details: WampDict,
-    arguments: Option<WampList>,
-    arguments_kw: Option<WampDict>,
+    arguments: Option<WampArgs>,
+    arguments_kw: Option<WampKwArgs>,
 ) -> Status {
     let rpc_func = match core.rpc_endpoints.get(&registration) {
         Some(e) => e,
@@ -189,8 +189,8 @@ pub async fn call_result(
     core: &mut Core,
     request: WampId,
     _details: WampDict,
-    arguments: Option<WampList>,
-    arguments_kw: Option<WampDict>,
+    arguments: Option<WampArgs>,
+    arguments_kw: Option<WampKwArgs>,
 ) -> Status {
     let res = match core.pending_call.remove(&request) {
         Some(r) => r,
@@ -240,8 +240,8 @@ pub async fn error(
     request: WampId,
     details: WampDict,
     error: WampUri,
-    _arguments: Option<WampList>,
-    _arguments_kw: Option<WampDict>,
+    _arguments: Option<WampArgs>,
+    _arguments_kw: Option<WampKwArgs>,
 ) -> Status {
     let error = WampError::ServerError(error, details);
     match typ {

--- a/src/core/send.rs
+++ b/src/core/send.rs
@@ -30,8 +30,8 @@ pub enum Request {
     Publish {
         uri: WampString,
         options: WampDict,
-        arguments: WampArgs,
-        arguments_kw: WampKwArgs,
+        arguments: Option<WampArgs>,
+        arguments_kw: Option<WampKwArgs>,
         res: Sender<Result<Option<WampId>, WampError>>,
     },
     Register {
@@ -45,13 +45,13 @@ pub enum Request {
     },
     InvocationResult {
         request: WampId,
-        res: Result<(WampArgs, WampKwArgs), WampError>,
+        res: Result<(Option<WampArgs>, Option<WampKwArgs>), WampError>,
     },
     Call {
         uri: WampString,
         options: WampDict,
-        arguments: WampArgs,
-        arguments_kw: WampKwArgs,
+        arguments: Option<WampArgs>,
+        arguments_kw: Option<WampKwArgs>,
         res: PendingCallResult,
     },
 }
@@ -196,8 +196,8 @@ pub async fn publish(
     core: &mut Core,
     uri: WampString,
     options: WampDict,
-    arguments: WampArgs,
-    arguments_kw: WampKwArgs,
+    arguments: Option<WampArgs>,
+    arguments_kw: Option<WampKwArgs>,
     res: Sender<Result<Option<WampId>, WampError>>,
 ) -> Status {
     let request = core.create_request();
@@ -285,7 +285,7 @@ pub async fn unregister(
 pub async fn invoke_yield(
     core: &mut Core,
     request: WampId,
-    res: Result<(WampArgs, WampKwArgs), WampError>,
+    res: Result<(Option<WampArgs>, Option<WampKwArgs>), WampError>,
 ) -> Status {
     let msg: Msg = match res {
         Ok((arguments, arguments_kw)) => Msg::Yield {
@@ -299,7 +299,7 @@ pub async fn invoke_yield(
             request,
             details: WampDict::new(),
             error: "wamp.async.rs.rpc.failed".to_string(),
-            arguments: Some(vec![Arg::String(format!("{:?}", e))]),
+            arguments: Some(vec![format!("{:?}", e).into()]),
             arguments_kw: None,
         },
     };
@@ -314,8 +314,8 @@ pub async fn call(
     core: &mut Core,
     uri: WampString,
     options: WampDict,
-    arguments: WampArgs,
-    arguments_kw: WampKwArgs,
+    arguments: Option<WampArgs>,
+    arguments_kw: Option<WampKwArgs>,
     res: PendingCallResult,
 ) -> Status {
     let request = core.create_request();

--- a/src/message.rs
+++ b/src/message.rs
@@ -45,16 +45,16 @@ pub enum Msg {
         request: WampId,
         details: WampDict,
         error: WampUri,
-        arguments: Option<WampList>,
-        arguments_kw: Option<WampDict>,
+        arguments: Option<WampArgs>,
+        arguments_kw: Option<WampKwArgs>,
     },
     /// Sent by a Publisher to a Broker to publish an event.
     Publish {
         request: WampId,
         options: WampDict,
         topic: WampUri,
-        arguments: Option<WampList>,
-        arguments_kw: Option<WampDict>,
+        arguments: Option<WampArgs>,
+        arguments_kw: Option<WampKwArgs>,
     },
     /// Acknowledge sent by a Broker to a Publisher for acknowledged publications.
     Published {
@@ -84,23 +84,23 @@ pub enum Msg {
         subscription: WampId,
         publication: WampId,
         details: WampDict,
-        arguments: Option<WampList>,
-        arguments_kw: Option<WampDict>,
+        arguments: Option<WampArgs>,
+        arguments_kw: Option<WampKwArgs>,
     },
     /// Call as originally issued by the Caller to the Dealer.
     Call {
         request: WampId,
         options: WampDict,
         procedure: WampUri,
-        arguments: Option<WampList>,
-        arguments_kw: Option<WampDict>,
+        arguments: Option<WampArgs>,
+        arguments_kw: Option<WampKwArgs>,
     },
     /// Result of a call as returned by Dealer to Caller.
     Result {
         request: WampId,
         details: WampDict,
-        arguments: Option<WampList>,
-        arguments_kw: Option<WampDict>,
+        arguments: Option<WampArgs>,
+        arguments_kw: Option<WampKwArgs>,
     },
     /// A Callees request to register an endpoint at a Dealer.
     Register {
@@ -125,15 +125,15 @@ pub enum Msg {
         request: WampId,
         registration: WampId,
         details: WampDict,
-        arguments: Option<WampList>,
-        arguments_kw: Option<WampDict>,
+        arguments: Option<WampArgs>,
+        arguments_kw: Option<WampKwArgs>,
     },
     /// Actual yield from an endpoint sent by a Callee to Dealer.
     Yield {
         request: WampId,
         options: WampDict,
-        arguments: Option<WampList>,
-        arguments_kw: Option<WampDict>,
+        arguments: Option<WampArgs>,
+        arguments_kw: Option<WampKwArgs>,
     },
 }
 


### PR DESCRIPTION
Payloads [positional and keyword arguments] should be able to use any type that can be serialized with the serialization format.

> The application payloads transmitted by WAMP (e.g. in call arguments or event payloads) may use other types a concrete serialization format supports.

[WAMP-proto specification](https://www.wamp-proto.org/_static/gen/wamp_latest.html#serializations)

*Resolves #1*: It is a breaking change to the API, so it should be 0.2.0 release.

/cc @afilini