### PR TITLE
feat: Use serde_json::Map instead of HashMap to enable easy (de)serializiation of structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ For usage examples, see :
     let ack_id = client.publish("peer.heartbeat", None, None, true).await?;
     println!("Ack id {}", ack_id.unwrap());
     ```
+
     ```rust
     // Register for events
     let (_sub_id, mut event_queue) = client.subscribe("peer.heartbeat").await?;
@@ -31,6 +32,7 @@ For usage examples, see :
     let (args, kwargs) = client.call("peer.echo", Some(vec![12.into()]), None).await?;
     println!("RPC returned {:?} {:?}", args, kwargs);
     ```
+
     ```rust
     // Declare your RPC function
     async fn rpc_echo(args: Option<WampArgs>, kwargs: Option<WampKwArgs>) -> Result<(Option<WampArgs>, Option<WampKwArgs>), WampError> {
@@ -41,6 +43,53 @@ For usage examples, see :
     // Register the function
     let rpc_id = client.register("peer.echo", rpc_echo).await?;
     ```
+
+
+## Structs Serialization and Deserialization
+
+```rust
+// Call endpoint with one argument
+let (args, kwargs) = client.call("peer.echo", Some(vec![12.into()]), None).await?;
+// or
+let (args, kwargs) = client.call("peer.echo", Some(wamp_async::try_into_args((12,))), None).await?;
+println!("RPC returned {:?} {:?}", args, kwargs);
+```
+
+```rust
+#[derive(serde::Deserialize, serde::Serialize)]
+struct MyKwArgs {
+    name: String,
+}
+
+// Declare your RPC function
+async fn rpc_echo(args: Option<WampArgs>, kwargs: Option<WampKwArgs>) -> Result<(Option<WampArgs>, Option<WampKwArgs>), WampError> {
+    // You only need serde-deserializable structure (e.g. a tuple of two integers)
+    let valid_args: (i32, i32) = if let Some(args) = args {
+        wamp_async::try_from_args(args)?
+    } else {
+        return Err(wamp_async::WampError::UnknownError("positional args are required".to_string()));
+    };
+    println!("Two integers are: {}, {}", valid_args.0, valid_args.1);
+
+    // You can also use a custom struct and use a little bit of Rust helpers
+    let valid_kwargs: Option<MyKwArgs> = kwargs.map(wamp_async::try_from_kwargs).transpose()?;
+
+    if let Some(MyKwArgs { name }) = valid_kwargs {
+        println!("Name is {}", name);
+    } else {
+        println!("There were no kwargs specified");
+    }
+
+    Ok((
+        Some(wamp_async::try_into_args(valid_args)?),
+        valid_kwargs.map(wamp_async::try_into_kwargs).transpose()?,
+    ))
+}
+
+// Register the function
+let rpc_id = client.register("peer.echo", rpc_echo).await?;
+```
+
 
 ## Features
 

--- a/examples/rpc_callee.rs
+++ b/examples/rpc_callee.rs
@@ -21,6 +21,34 @@ async fn echo(
     Ok((args, kwargs))
 }
 
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct MyArgs(i64, i64);
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct MyKwArgs {
+    name: String,
+    age: u8,
+}
+
+// Validate structure and return the rpc arguments
+async fn strict_echo(
+    args: Option<WampArgs>,
+    kwargs: Option<WampKwArgs>,
+) -> Result<(Option<WampArgs>, Option<WampKwArgs>), WampError> {
+    println!("peer.strict_echo raw input {:?} {:?}", args, kwargs);
+
+    let valid_args: Option<MyArgs> = args.map(wamp_async::try_from_args).transpose()?;
+    let valid_kwargs: Option<MyKwArgs> = kwargs.map(wamp_async::try_from_kwargs).transpose()?;
+    println!("peer.strict_echo deserialized input {:?} {:?}", valid_args, valid_kwargs);
+
+    let _ = RPC_CALL_COUNT.fetch_add(1, Ordering::Relaxed);
+
+    Ok((
+        valid_args.map(wamp_async::try_into_args).transpose()?,
+        valid_kwargs.map(wamp_async::try_into_kwargs).transpose()?,
+    ))
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
@@ -60,8 +88,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("Joining realm");
     client.join_realm("realm1").await?;
 
-    // Register our function to a uri
-    let rpc_id = client.register("peer.echo", echo).await?;
+    // Register our functions to a uri
+    let echo_rpc_id = client.register("peer.echo", echo).await?;
+    let strict_echo_rpc_id = client.register("peer.strict_echo", strict_echo).await?;
 
     println!("Waiting for 'peer.echo' to be called at least 4 times");
     loop {
@@ -78,7 +107,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         return Err(From::from("Unexpected disconnect".to_string()));
     }
 
-    client.unregister(rpc_id).await?;
+    client.unregister(echo_rpc_id).await?;
+    client.unregister(strict_echo_rpc_id).await?;
 
     println!("Leaving realm");
     client.leave_realm().await?;


### PR DESCRIPTION
Also, added helper methods for WampArgs and WampKwArgs:

* `wamp_async::try_from_any_value`
* `wamp_async::try_from_args`
* `wamp_async::try_from_kwargs`
* `wamp_async::try_to_any_value`
* `wamp_async::try_to_args`
* `wamp_async::try_to_kwargs`