### PR TITLE
feat: Use explicit lifetime for RpcFunc, thus allowing non-static lifetimes

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -178,9 +178,15 @@ pub fn is_valid_strict_uri<T: AsRef<str>>(in_uri: T) -> bool {
 }
 
 /// Future that can return success or an error
-pub type GenericFuture = Pin<Box<dyn Future<Output = Result<(), WampError>> + Send>>;
+pub type GenericFuture<'a> = Pin<Box<dyn Future<Output = Result<(), WampError>> + Send + 'a>>;
 /// Type returned by RPC functions
-pub type RpcFuture =
-    Pin<Box<dyn Future<Output = Result<(Option<WampArgs>, Option<WampKwArgs>), WampError>> + Send>>;
+pub type RpcFuture<'a> = std::pin::Pin<
+    Box<
+        dyn std::future::Future<Output = Result<(Option<WampArgs>, Option<WampKwArgs>), WampError>>
+            + Send
+            + 'a,
+    >,
+>;
 /// Generic function that can receive RPC calls
-pub type RpcFunc = Box<dyn Fn(Option<WampArgs>, Option<WampKwArgs>) -> RpcFuture + Send + Sync>;
+pub type RpcFunc<'a> =
+    Box<dyn Fn(Option<WampArgs>, Option<WampKwArgs>) -> RpcFuture<'a> + Send + Sync + 'a>;

--- a/src/core/recv.rs
+++ b/src/core/recv.rs
@@ -1,6 +1,6 @@
 use crate::core::*;
 
-pub async fn subscribed(core: &mut Core, request: WampId, sub_id: WampId) -> Status {
+pub async fn subscribed(core: &mut Core<'_>, request: WampId, sub_id: WampId) -> Status {
     let res = match core.pending_sub.remove(&request) {
         Some(v) => v,
         None => {
@@ -26,7 +26,7 @@ pub async fn subscribed(core: &mut Core, request: WampId, sub_id: WampId) -> Sta
 
     Status::Ok
 }
-pub async fn unsubscribed(core: &mut Core, request: WampId) -> Status {
+pub async fn unsubscribed(core: &mut Core<'_>, request: WampId) -> Status {
     let res = match core.pending_transactions.remove(&request) {
         Some(v) => v,
         None => {
@@ -43,7 +43,7 @@ pub async fn unsubscribed(core: &mut Core, request: WampId) -> Status {
 
     Status::Ok
 }
-pub async fn published(core: &mut Core, request: WampId, pub_id: WampId) -> Status {
+pub async fn published(core: &mut Core<'_>, request: WampId, pub_id: WampId) -> Status {
     let res = match core.pending_transactions.remove(&request) {
         Some(v) => v,
         None => {
@@ -59,7 +59,7 @@ pub async fn published(core: &mut Core, request: WampId, pub_id: WampId) -> Stat
     Status::Ok
 }
 pub async fn event(
-    core: &mut Core,
+    core: &mut Core<'_>,
     subscription: WampId,
     publication: WampId,
     _details: WampDict,
@@ -91,7 +91,7 @@ pub async fn event(
 
     Status::Ok
 }
-pub async fn registered(core: &mut Core, request: WampId, rpc_id: WampId) -> Status {
+pub async fn registered(core: &mut Core<'_>, request: WampId, rpc_id: WampId) -> Status {
     let (rpc_func, res) = match core.pending_register.remove(&request) {
         Some(v) => v,
         None => {
@@ -117,7 +117,7 @@ pub async fn registered(core: &mut Core, request: WampId, rpc_id: WampId) -> Sta
 
     Status::Ok
 }
-pub async fn unregisterd(core: &mut Core, request: WampId) -> Status {
+pub async fn unregisterd(core: &mut Core<'_>, request: WampId) -> Status {
     let res = match core.pending_transactions.remove(&request) {
         Some(v) => v,
         None => {
@@ -134,9 +134,9 @@ pub async fn unregisterd(core: &mut Core, request: WampId) -> Status {
 
 /// Runs the RPC function and forwards the result
 async fn rpc_func_runner(
-    ctl_channel: UnboundedSender<Request>,
+    ctl_channel: UnboundedSender<Request<'_>>,
     request: WampId,
-    rpc_func: RpcFuture,
+    rpc_func: RpcFuture<'_>,
 ) -> Result<(), WampError> {
     // Run the RPC func
     let res = rpc_func.await;
@@ -149,7 +149,7 @@ async fn rpc_func_runner(
 }
 
 pub async fn invocation(
-    core: &mut Core,
+    core: &mut Core<'_>,
     request: WampId,
     registration: WampId,
     _details: WampDict,
@@ -186,7 +186,7 @@ pub async fn invocation(
     Status::Ok
 }
 pub async fn call_result(
-    core: &mut Core,
+    core: &mut Core<'_>,
     request: WampId,
     _details: WampDict,
     arguments: Option<WampArgs>,
@@ -212,7 +212,7 @@ pub async fn call_result(
     Status::Ok
 }
 
-pub async fn goodbye(core: &mut Core, details: WampDict, reason: WampString) -> Status {
+pub async fn goodbye(core: &mut Core<'_>, details: WampDict, reason: WampString) -> Status {
     debug!("Server sent goodbye : {:?} {:?}", details, reason);
 
     if !core.valid_session && reason == "wamp.close.goodbye_and_out" {
@@ -229,13 +229,13 @@ pub async fn goodbye(core: &mut Core, details: WampDict, reason: WampString) -> 
     }
 }
 
-pub async fn abort(_core: &mut Core, details: WampDict, reason: WampString) -> Status {
+pub async fn abort(_core: &mut Core<'_>, details: WampDict, reason: WampString) -> Status {
     error!("Server sent abort : {:?} {:?}", details, reason);
     Status::Shutdown
 }
 // Handles an error sent by the peer
 pub async fn error(
-    core: &mut Core,
+    core: &mut Core<'_>,
     typ: WampInteger,
     request: WampId,
     details: WampDict,

--- a/src/core/send.rs
+++ b/src/core/send.rs
@@ -8,7 +8,7 @@ use crate::core::*;
 use crate::message::*;
 
 pub type JoinRealmResult = Result<(WampId, HashMap<WampString, Arg>), WampError>;
-pub enum Request {
+pub enum Request<'a> {
     Shutdown,
     Join {
         uri: WampString,
@@ -37,7 +37,7 @@ pub enum Request {
     Register {
         uri: WampString,
         res: PendingRegisterResult,
-        func_ptr: RpcFunc,
+        func_ptr: RpcFunc<'a>,
     },
     Unregister {
         rpc_id: WampId,
@@ -58,7 +58,7 @@ pub enum Request {
 
 /// Handler for any join realm request. This will send a HELLO and wait for the WELCOME response
 pub async fn join_realm(
-    core: &mut Core,
+    core: &mut Core<'_>,
     uri: WampString,
     roles: HashSet<ClientRole>,
     mut agent_str: Option<WampString>,
@@ -117,7 +117,7 @@ pub async fn join_realm(
 }
 
 /// Handler for any leave realm request. This function will send a GOODBYE and wait for a GOODBYE response
-pub async fn leave_realm(core: &mut Core, res: Sender<Result<(), WampError>>) -> Status {
+pub async fn leave_realm(core: &mut Core<'_>, res: Sender<Result<(), WampError>>) -> Status {
     core.valid_session = false;
 
     if let Err(e) = core
@@ -136,7 +136,7 @@ pub async fn leave_realm(core: &mut Core, res: Sender<Result<(), WampError>>) ->
     Status::Ok
 }
 
-pub async fn subscribe(core: &mut Core, topic: WampString, res: PendingSubResult) -> Status {
+pub async fn subscribe(core: &mut Core<'_>, topic: WampString, res: PendingSubResult) -> Status {
     let request = core.create_request();
 
     if let Err(e) = core
@@ -158,7 +158,7 @@ pub async fn subscribe(core: &mut Core, topic: WampString, res: PendingSubResult
 }
 
 pub async fn unsubscribe(
-    core: &mut Core,
+    core: &mut Core<'_>,
     sub_id: WampId,
     res: Sender<Result<Option<WampId>, WampError>>,
 ) -> Status {
@@ -193,7 +193,7 @@ pub async fn unsubscribe(
 }
 
 pub async fn publish(
-    core: &mut Core,
+    core: &mut Core<'_>,
     uri: WampString,
     options: WampDict,
     arguments: Option<WampArgs>,
@@ -222,11 +222,11 @@ pub async fn publish(
     Status::Ok
 }
 
-pub async fn register(
-    core: &mut Core,
+pub async fn register<'a>(
+    core: &mut Core<'a>,
     uri: WampString,
     res: PendingRegisterResult,
-    func_ptr: RpcFunc,
+    func_ptr: RpcFunc<'a>,
 ) -> Status {
     let request = core.create_request();
 
@@ -248,7 +248,7 @@ pub async fn register(
 }
 
 pub async fn unregister(
-    core: &mut Core,
+    core: &mut Core<'_>,
     rpc_id: WampId,
     res: Sender<Result<Option<WampId>, WampError>>,
 ) -> Status {
@@ -283,7 +283,7 @@ pub async fn unregister(
 }
 
 pub async fn invoke_yield(
-    core: &mut Core,
+    core: &mut Core<'_>,
     request: WampId,
     res: Result<(Option<WampArgs>, Option<WampKwArgs>), WampError>,
 ) -> Status {
@@ -311,7 +311,7 @@ pub async fn invoke_yield(
 }
 
 pub async fn call(
-    core: &mut Core,
+    core: &mut Core<'_>,
     uri: WampString,
     options: WampDict,
     arguments: Option<WampArgs>,


### PR DESCRIPTION
This change is not effective if you spawn `evt_loop` with `tokio::spawn` as the latter requires `'static` lifetime, so it poisons the client, and the core with `'static` requirement. I ended up using `Arc` for the context state anyway, so these changes are not solving any particular issue, but I still think it might be worth having it specified this way to potentially relax some future use-cases.