### PR TITLE
Specify tokio-tungstenite version to build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rmp-serde = "0.14"
 rand = "0.3"
-tokio-tungstenite = {version = "0", features = ["tls"]}
+tokio-tungstenite = {version = "0.11", features = ["tls"]}
 native-tls = "0.2"
 tokio-tls = "0.3"
 futures = "0"


### PR DESCRIPTION
This issue resolves building wamp_async (see #9)

Changes:
- `tokio-tungstenite` version pinned to 0.11