### PR TITLE
Exposed options to client.subscribe

### DIFF
--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use wamp_async::{Client, ClientConfig};
+use wamp_async::{Client, ClientConfig, WampDict};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         println!(
             "Subscribing to peer.heartbeat events. Start another instance with a 'pub' argument"
         );
-        let (sub_id, mut heartbeat_queue) = client.subscribe("peer.heartbeat").await?;
+        let (sub_id, mut heartbeat_queue) = client.subscribe("peer.heartbeat", WampDict::new()).await?;
         println!("Waiting for {} heartbeats...", max_events);
 
         while cur_event_num < max_events {

--- a/src/client.rs
+++ b/src/client.rs
@@ -397,11 +397,13 @@ impl<'a> Client<'a> {
     pub async fn subscribe<T: AsRef<str>>(
         &self,
         topic: T,
+        options: WampDict,
     ) -> Result<(WampId, SubscriptionQueue), WampError> {
         // Send the request
         let (res, result) = oneshot::channel();
         if let Err(e) = self.ctl_channel.send(Request::Subscribe {
             uri: topic.as_ref().to_string(),
+            options,
             res,
         }) {
             return Err(From::from(format!(

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -320,7 +320,7 @@ impl<'a> Core<'a> {
                 .await
             }
             Request::Leave { res } => send::leave_realm(self, res).await,
-            Request::Subscribe { uri, res } => send::subscribe(self, uri, res).await,
+            Request::Subscribe { uri, options, res } => send::subscribe(self, uri, options, res).await,
             Request::Unsubscribe { sub_id, res } => send::unsubscribe(self, sub_id, res).await,
             Request::Publish {
                 uri,

--- a/src/core/send.rs
+++ b/src/core/send.rs
@@ -24,6 +24,7 @@ pub enum Request<'a> {
     },
     Subscribe {
         uri: WampString,
+        options: WampDict,
         res: PendingSubResult,
     },
     Unsubscribe {
@@ -187,14 +188,14 @@ pub async fn leave_realm(core: &mut Core<'_>, res: Sender<Result<(), WampError>>
     Status::Ok
 }
 
-pub async fn subscribe(core: &mut Core<'_>, topic: WampString, res: PendingSubResult) -> Status {
+pub async fn subscribe(core: &mut Core<'_>, topic: WampString, options: WampDict, res: PendingSubResult) -> Status {
     let request = core.create_request();
 
     if let Err(e) = core
         .send(&Msg::Subscribe {
             request,
             topic,
-            options: WampDict::new(),
+            options,
         })
         .await
     {


### PR DESCRIPTION
Acqually a client cannot subscribe to a topic and send options like `{"match":"prefix"}`.
This patch expose the wamp `options` parameter in `subscribe` method.
Here the wamp documentation: https://wamp-proto.org/_static/gen/wamp_latest.html#subscribe-0