### PR TITLE
Feature/pattern based subscriptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "An asynchronous WAMP implementation"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "wamp_async"
-version = "0.3.2-alpha.0"
+version = "0.4.0-alpha.0"
 
 categories = ["network-programming", "web-programming", "asynchronous"]
 documentation = "https://docs.rs/wamp_async"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
-authors = ["ElasT0ny <elast0ny00@gmail.com>"]
+authors = [
+    "ElasT0ny <elast0ny00@gmail.com>",
+    "Devon Bagley <devonbagley@gmail.com>"
+]
 description = "An asynchronous WAMP implementation"
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ For usage examples, see :
 
   ```rust
   // Register for events
-  let (_sub_id, mut event_queue) = client.subscribe("peer.heartbeat").await?;
+  let (_sub_id, mut event_queue) = client.subscribe("peer.heartbeat", SubOptions::empty()).await?;
   // Wait for the next event
   match event_queue.recv().await {
-      Some((_pub_id, args, kwargs)) => println!("Event(args: {:?}, kwargs: {:?})", args, kwargs),
+      Some((_pub_id, _details, args, kwargs)) => println!("Event(args: {:?}, kwargs: {:?})", args, kwargs),
       None => println!("Event queue closed"),
   };
   ```
@@ -116,10 +116,11 @@ let rpc_id = client.register("peer.echo", rpc_echo).await?;
 
 #### Advanced profile:
 
-| Feature               | Desciption                                                      | Status      |
-| --------------------- | --------------------------------------------------------------- | ----------- |
-| Client Authentication | Low-level support for Client Authentication (Ticket-based, CRA) | ✔           |
-| Progressive Calls     | Partial results reported from Callee to Caller                  | help wanted |
+| Feature                     | Desciption                                                      | Status      |
+| --------------------------- | --------------------------------------------------------------- | ----------- |
+| Client Authentication       | Low-level support for Client Authentication (Ticket-based, CRA) | ✔           |
+| Pattern Based Subscriptions | Wildcard, and Prefix matches for channel topics                 | ✔           |
+| Progressive Calls           | Partial results reported from Callee to Caller                  | help wanted |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For usage examples, see :
 
   ```rust
   // Register for events
-  let (_sub_id, mut event_queue) = client.subscribe("peer.heartbeat", SubOptions::empty()).await?;
+  let (_sub_id, mut event_queue) = client.subscribe("peer.heartbeat", SubscribeOptions::empty()).await?;
   // Wait for the next event
   match event_queue.recv().await {
       Some((_pub_id, _details, args, kwargs)) => println!("Event(args: {:?}, kwargs: {:?})", args, kwargs),

--- a/examples/pattern_based_subscription.rs
+++ b/examples/pattern_based_subscription.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use wamp_async::{Client, ClientConfig, SubOptions, Arg};
+use wamp_async::{Client, ClientConfig, OptionBuilder, SubscribeOptions, Arg};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -45,9 +45,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
             "Subscribing to peer.heartbeat events. Start another instance with a 'pub' argument"
         );
         // Prefix Match
-        let (sub_id, mut heartbeat_queue) = client.subscribe("peer.heartbeat", SubOptions::new().with_match("prefix")).await?;
+        let (sub_id, mut heartbeat_queue) = client.subscribe("peer.heartbeat", SubscribeOptions::new().with_match("prefix")).await?;
         // Wildcard match with empty uri part
-        let (sub_id, mut heartbeat_last) = client.subscribe("peer..9", SubOptions::new().with_match("wildcard")).await?;
+        let (last_sub_id, mut heartbeat_last) = client.subscribe("peer..9", SubscribeOptions::new().with_match("wildcard")).await?;
         println!("Waiting for {} heartbeats...", max_events);
 
         while cur_event_num < max_events {
@@ -55,24 +55,26 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 pre = heartbeat_queue.recv() => match pre {
                     Some((pub_id, details, args, kwargs)) => {
                         println!("\tGot {} (details: {:?} args: {:?}, kwargs: {:?})", pub_id, details, args, kwargs);
+                        // The publisher gives us the current event number in the topic.
                         cur_event_num = match &details["topic"] {
                             Arg::Uri(topic) => topic.split(".").collect::<Vec<&str>>().last().unwrap().parse::<usize>().unwrap(),
-                            _ => 0
-                        };
+                            _ => panic!("We got an event with no topic")
+                        } + 1;
                     },
                     None => println!("Subscription is done"),
                 }
 
                 last = heartbeat_last.recv() => match last {
                     Some((pub_id, details, args, kwargs)) => {
+                        // We know we are done here.
+                        client.unsubscribe(last_sub_id).await?;
+                        client.unsubscribe(sub_id).await?;
                         println!("\tLast Heartbeat: {} (details: {:?} args: {:?}, kwargs: {:?})", pub_id, details, args, kwargs)
                     },
                     None => println!("Subscription is done"),
                 }
             }
         }
-
-        client.unsubscribe(sub_id).await?;
     }
 
     println!("Leaving realm");

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         println!(
             "Subscribing to peer.heartbeat events. Start another instance with a 'pub' argument"
         );
-        let (sub_id, mut heartbeat_queue) = client.subscribe("peer.heartbeat").await?;
+        let (sub_id, mut heartbeat_queue) = client.subscribe("peer.heartbeat", None).await?;
         println!("Waiting for {} heartbeats...", max_events);
 
         while cur_event_num < max_events {

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use wamp_async::{Client, ClientConfig, SubOptions};
+use wamp_async::{Client, ClientConfig, OptionBuilder, SubscribeOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         println!(
             "Subscribing to peer.heartbeat events. Start another instance with a 'pub' argument"
         );
-        let (sub_id, mut heartbeat_queue) = client.subscribe("peer.heartbeat", SubOptions::new()).await?;
+        let (sub_id, mut heartbeat_queue) = client.subscribe("peer.heartbeat", SubscribeOptions::new()).await?;
         println!("Waiting for {} heartbeats...", max_events);
 
         while cur_event_num < max_events {

--- a/src/client.rs
+++ b/src/client.rs
@@ -397,13 +397,13 @@ impl<'a> Client<'a> {
     pub async fn subscribe<T: AsRef<str>>(
         &self,
         topic: T,
-        options: Option<WampDict>
+        options: SubOptions
     ) -> Result<(WampId, SubscriptionQueue), WampError> {
         // Send the request
         let (res, result) = oneshot::channel();
         if let Err(e) = self.ctl_channel.send(Request::Subscribe {
             uri: topic.as_ref().to_string(),
-            options: match options {
+            options: match options.get_dict() {
                 Some(dict) => dict,
                 None => WampDict::new(),
             },

--- a/src/client.rs
+++ b/src/client.rs
@@ -397,11 +397,16 @@ impl<'a> Client<'a> {
     pub async fn subscribe<T: AsRef<str>>(
         &self,
         topic: T,
+        options: Option<WampDict>
     ) -> Result<(WampId, SubscriptionQueue), WampError> {
         // Send the request
         let (res, result) = oneshot::channel();
         if let Err(e) = self.ctl_channel.send(Request::Subscribe {
             uri: topic.as_ref().to_string(),
+            options: match options {
+                Some(dict) => dict,
+                None => WampDict::new(),
+            },
             res,
         }) {
             return Err(From::from(format!(

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,6 +12,7 @@ use url::*;
 pub use crate::common::*;
 use crate::core::*;
 use crate::error::*;
+use crate::options::*;
 use crate::serializer::SerializerType;
 
 /// Options one can set when connecting to a WAMP server
@@ -397,7 +398,7 @@ impl<'a> Client<'a> {
     pub async fn subscribe<T: AsRef<str>>(
         &self,
         topic: T,
-        options: SubOptions
+        options: SubscribeOptions
     ) -> Result<(WampId, SubscriptionQueue), WampError> {
         // Send the request
         let (res, result) = oneshot::channel();

--- a/src/common.rs
+++ b/src/common.rs
@@ -67,13 +67,13 @@ pub type WampKwArgs = serde_json::Map<String, WampPayloadValue>;
 pub struct SubOptions(Option<WampDict>);
 
 impl SubOptions {
-    pub fn with_match(&self, matchOpt: String) -> Self {
+    pub fn with_match(&self, match_option: &str) -> Self {
         let mut options = match &self.0 {
             Some(opts) => opts.clone(),
             None => WampDict::new(),
         };
 
-        options.insert("match".to_string(), Arg::String(matchOpt));
+        options.insert("match".to_string(), Arg::String(match_option.to_owned()));
 
         SubOptions(Some(options))
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -108,6 +108,7 @@ impl ClientRole {
         }
     }
 
+    /// Creates a features dictionary to declare for the role
     pub fn get_features(&self) -> WampDict {
         match self {
             ClientRole::Subscriber => {
@@ -121,7 +122,8 @@ impl ClientRole {
         }
     }
 
-    pub fn has_features(&self) -> WampBool {
+    /// Returns true if the role has features that need to be declared
+    pub fn has_features(&self) -> bool {
         match self {
             ClientRole::Subscriber => true,
             _ => false

--- a/src/common.rs
+++ b/src/common.rs
@@ -64,39 +64,6 @@ pub type WampArgs = Vec<WampPayloadValue>;
 /// Named WAMP argument map
 pub type WampKwArgs = serde_json::Map<String, WampPayloadValue>;
 
-pub struct SubOptions(Option<WampDict>);
-
-impl SubOptions {
-    pub fn with_match(&self, match_option: &str) -> Self {
-        let mut options = match &self.0 {
-            Some(opts) => opts.clone(),
-            None => WampDict::new(),
-        };
-
-        options.insert("match".to_string(), Arg::String(match_option.to_owned()));
-
-        SubOptions(Some(options))
-    }
-
-    pub fn new() -> Self {
-        Self::empty()
-    }
-
-    pub fn empty() -> Self {
-        SubOptions(None)
-    }
-
-    pub fn get_dict(&self) -> Option<WampDict> {
-        self.0.clone()
-    }
-}
-
-impl Default for SubOptions {
-    fn default() -> Self {
-        Self::empty()
-    }
-}
-
 /// Generic enum that can hold any concrete WAMP value
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -64,8 +64,41 @@ pub type WampArgs = Vec<WampPayloadValue>;
 /// Named WAMP argument map
 pub type WampKwArgs = serde_json::Map<String, WampPayloadValue>;
 
+pub struct SubOptions(Option<WampDict>);
+
+impl SubOptions {
+    pub fn with_match(&self, matchOpt: String) -> Self {
+        let mut options = match &self.0 {
+            Some(opts) => opts.clone(),
+            None => WampDict::new(),
+        };
+
+        options.insert("match".to_string(), Arg::String(matchOpt));
+
+        SubOptions(Some(options))
+    }
+
+    pub fn new() -> Self {
+        Self::empty()
+    }
+
+    pub fn empty() -> Self {
+        SubOptions(None)
+    }
+
+    pub fn get_dict(&self) -> Option<WampDict> {
+        self.0.clone()
+    }
+}
+
+impl Default for SubOptions {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
 /// Generic enum that can hold any concrete WAMP value
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum Arg {
     /// uri: a string URI as defined in URIs

--- a/src/common.rs
+++ b/src/common.rs
@@ -140,6 +140,26 @@ impl ClientRole {
             ClientRole::Subscriber => "subscriber",
         }
     }
+
+    pub fn get_features(&self) -> WampDict {
+        match self {
+            ClientRole::Subscriber => {
+                let mut features = WampDict::new();
+                for feature in vec!["pattern_based_subscription"] {
+                    features.insert(feature.to_owned(), Arg::Bool(true));
+                }
+                features.clone()
+            },
+            _ => WampDict::new()
+        }
+    }
+
+    pub fn has_features(&self) -> WampBool {
+        match self {
+            ClientRole::Subscriber => true,
+            _ => false
+        }
+    }
 }
 
 /// All the supported roles a server can have

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -35,6 +35,7 @@ pub type JoinResult = Sender<
 >;
 pub type SubscriptionQueue = UnboundedReceiver<(
     WampId,           // Publish event ID
+    WampDict,        // Publish event Details
     Option<WampArgs>, // Publish args
     Option<WampKwArgs>,
 )>; // publish kwargs
@@ -83,7 +84,7 @@ pub struct Core<'a> {
     /// Pending subscription requests sent to the server
     pending_sub: HashMap<WampId, PendingSubResult>,
     /// Current subscriptions
-    subscriptions: HashMap<WampId, UnboundedSender<(WampId, Option<WampArgs>, Option<WampKwArgs>)>>,
+    subscriptions: HashMap<WampId, UnboundedSender<(WampId, WampDict, Option<WampArgs>, Option<WampKwArgs>)>>,
 
     /// Pending RPC registration requests sent to the server
     pending_register: HashMap<WampId, (RpcFunc<'a>, PendingRegisterResult)>,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,6 +15,7 @@ mod send;
 
 use crate::client;
 use crate::message::*;
+use crate::Arg;
 pub use send::Request;
 
 pub enum Status {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -320,7 +320,7 @@ impl<'a> Core<'a> {
                 .await
             }
             Request::Leave { res } => send::leave_realm(self, res).await,
-            Request::Subscribe { uri, res } => send::subscribe(self, uri, res).await,
+            Request::Subscribe { uri, options, res } => send::subscribe(self, uri, options, res).await,
             Request::Unsubscribe { sub_id, res } => send::unsubscribe(self, sub_id, res).await,
             Request::Publish {
                 uri,

--- a/src/core/recv.rs
+++ b/src/core/recv.rs
@@ -62,7 +62,7 @@ pub async fn event(
     core: &mut Core<'_>,
     subscription: WampId,
     publication: WampId,
-    _details: WampDict,
+    details: WampDict,
     arguments: Option<WampArgs>,
     arguments_kw: Option<WampKwArgs>,
 ) -> Status {
@@ -79,7 +79,7 @@ pub async fn event(
 
     // Forward the event to the client
     if evt_queue
-        .send((publication, arguments, arguments_kw))
+        .send((publication, details, arguments, arguments_kw))
         .is_err()
     {
         warn!(

--- a/src/core/send.rs
+++ b/src/core/send.rs
@@ -75,7 +75,14 @@ pub async fn join_realm(
     let mut client_roles: WampDict = WampDict::new();
     // Add all of our roles
     for role in &roles {
-        client_roles.insert(String::from(role.to_str()), Arg::Dict(WampDict::new()));
+        let mut roledict = WampDict::new();
+        // Support for pattern_based_subscription MUST be announced by Subscribers.
+        // Crossbar doesn't enforce this, but other brokers might.
+        if role.has_features() {
+            roledict.insert("features".to_owned(), Arg::Dict(role.get_features()));
+        }
+        
+        client_roles.insert(String::from(role.to_str()), Arg::Dict(roledict.clone()));
     }
     details.insert("roles".to_owned(), Arg::Dict(client_roles));
 

--- a/src/core/send.rs
+++ b/src/core/send.rs
@@ -24,6 +24,7 @@ pub enum Request<'a> {
     },
     Subscribe {
         uri: WampString,
+        options: WampDict,
         res: PendingSubResult,
     },
     Unsubscribe {
@@ -187,14 +188,19 @@ pub async fn leave_realm(core: &mut Core<'_>, res: Sender<Result<(), WampError>>
     Status::Ok
 }
 
-pub async fn subscribe(core: &mut Core<'_>, topic: WampString, res: PendingSubResult) -> Status {
+pub async fn subscribe(
+    core: &mut Core<'_>,
+    topic: WampString,
+    options: WampDict,
+    res: PendingSubResult
+) -> Status {
     let request = core.create_request();
 
     if let Err(e) = core
         .send(&Msg::Subscribe {
             request,
             topic,
-            options: WampDict::new(),
+            options
         })
         .await
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,10 @@ mod error;
 mod message;
 mod serializer;
 mod transport;
+mod options;
 
 pub use client::{Client, ClientConfig, ClientState};
 pub use common::*;
 pub use error::*;
 pub use serializer::SerializerType;
+pub use options::*;

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -1,0 +1,5 @@
+mod subscription;
+mod option;
+
+pub use option::OptionBuilder;
+pub use subscription::SubscribeOptions;

--- a/src/options/option.rs
+++ b/src/options/option.rs
@@ -1,0 +1,56 @@
+use crate::{
+    Arg,
+    WampDict,
+    WampString,
+};
+
+#[derive(Debug, Clone)]
+pub enum WampOption<K, V> {
+    PublishOption(K, V),
+    SubscribeOption(K, V),
+    CallOption(K, V),
+    RegisterOption(K, V),
+    None
+}
+
+pub trait OptionBuilder {
+
+    fn with_option(&self, option: WampOption<String, Arg>) -> Self where Self: OptionBuilder + Sized {
+        let mut next_options = match &self.get_dict() {
+            Some(opts) => opts.clone(),
+            None => WampDict::new()
+        };
+
+        let (key, value) = match Self::validate_option(option.clone()) {
+            Some(result) => result,
+            None => panic!("Can't create invalid option {:?}", option)
+        };
+
+        next_options.insert(key, value);
+
+        Self::create(Some(next_options.clone()))
+    }
+
+    // TODO: Actual validation per role here
+    fn validate_option(option: WampOption<String, Arg>) -> Option<(WampString, Arg)> {
+        match option {
+            WampOption::PublishOption(key, value) => Some((key, value)),
+            WampOption::SubscribeOption(key, value) => Some((key, value)),
+            WampOption::RegisterOption(key, value) => Some((key, value)),
+            WampOption::CallOption(key, value) => Some((key, value)),
+            WampOption::None => None,
+        }
+    }
+    
+    fn new() -> Self where Self: OptionBuilder + Sized {
+        Self::empty()
+    }
+
+    fn empty() -> Self where Self: OptionBuilder + Sized {
+        Self::create(None)
+    }
+
+    fn create(options: Option<WampDict>) -> Self where Self: OptionBuilder + Sized;
+    fn get_dict(&self) -> Option<WampDict>;
+    
+}

--- a/src/options/option.rs
+++ b/src/options/option.rs
@@ -5,16 +5,26 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
+/// Options specific to roles for key/value pairs
 pub enum WampOption<K, V> {
+    /// A publisher role feature option
     PublishOption(K, V),
+    /// A Subscriber role feature option
     SubscribeOption(K, V),
+    /// A Caller role feature option
     CallOption(K, V),
+    /// A Callee role feature option
     RegisterOption(K, V),
+    /// An empty option
     None
 }
 
+/// Provides generic functionality for role options dictionary generation
 pub trait OptionBuilder {
 
+    /// Clones or creates a WampDict and inserts the key/value pair from the supplied WampOption
+    /// 
+    /// * `option` - The key/value pair to insert into the dictionary
     fn with_option(&self, option: WampOption<String, Arg>) -> Self where Self: OptionBuilder + Sized {
         let mut next_options = match &self.get_dict() {
             Some(opts) => opts.clone(),
@@ -32,6 +42,10 @@ pub trait OptionBuilder {
     }
 
     // TODO: Actual validation per role here
+    /// WIP (currently not functional)
+    /// Validate that the option being passed in is relevant for the role, and that they type of the value is correct for the given key.
+    /// 
+    /// * `option` - The key/value pair to validate
     fn validate_option(option: WampOption<String, Arg>) -> Option<(WampString, Arg)> {
         match option {
             WampOption::PublishOption(key, value) => Some((key, value)),
@@ -42,15 +56,21 @@ pub trait OptionBuilder {
         }
     }
     
+    /// Create a new empty builder - provided for convention
     fn new() -> Self where Self: OptionBuilder + Sized {
         Self::empty()
     }
 
+    /// Create a new empty builder
     fn empty() -> Self where Self: OptionBuilder + Sized {
         Self::create(None)
     }
 
+    /// Create an OptionBuilder using the provided WampDict
+    /// Must implement
     fn create(options: Option<WampDict>) -> Self where Self: OptionBuilder + Sized;
+    /// Return the current builder WampDict
+    /// Must implement
     fn get_dict(&self) -> Option<WampDict>;
-    
+
 }

--- a/src/options/subscription.rs
+++ b/src/options/subscription.rs
@@ -1,0 +1,34 @@
+use crate::{
+    WampDict,
+    Arg
+};
+use crate::options::option::{
+    OptionBuilder,
+    WampOption,
+};
+
+pub struct SubscriptionOptionItem(Option<WampDict>);
+
+impl SubscriptionOptionItem {
+    pub fn with_match(&self, match_option: &str) -> Self {
+        self.with_option(WampOption::SubscribeOption("match".to_owned(), Arg::String(match_option.to_owned())))
+    }
+}
+
+impl OptionBuilder for SubscriptionOptionItem {
+    fn create(options: Option<WampDict>) -> Self where Self: OptionBuilder + Sized {
+        Self(options)
+    }
+
+    fn get_dict(&self) -> Option<WampDict> {
+        self.0.clone()
+    }
+}
+
+impl Default for SubscriptionOptionItem {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+pub type SubscribeOptions = SubscriptionOptionItem;

--- a/src/options/subscription.rs
+++ b/src/options/subscription.rs
@@ -7,28 +7,37 @@ use crate::options::option::{
     WampOption,
 };
 
+/// Base struct for storing WampDict value
 pub struct SubscriptionOptionItem(Option<WampDict>);
 
+/// Provides functions for adding defined options to the WampDict
 impl SubscriptionOptionItem {
+    /// Add an option for pattern matching the topic of the subscription
     pub fn with_match(&self, match_option: &str) -> Self {
         self.with_option(WampOption::SubscribeOption("match".to_owned(), Arg::String(match_option.to_owned())))
     }
 }
 
+/// Add base OptionBuilder functionality
 impl OptionBuilder for SubscriptionOptionItem {
+    /// Build a new SubscriptionOptionItem from a provided Option<WampDict>
     fn create(options: Option<WampDict>) -> Self where Self: OptionBuilder + Sized {
         Self(options)
     }
 
+    /// Return the WampDict being operated on and stored by SubscriptionOptionItem
     fn get_dict(&self) -> Option<WampDict> {
         self.0.clone()
     }
 }
 
+/// Default
 impl Default for SubscriptionOptionItem {
+    /// Create a new empty SubscriptionOptionItem
     fn default() -> Self {
         Self::empty()
     }
 }
 
+/// Alias for SubscriptionOptionItem
 pub type SubscribeOptions = SubscriptionOptionItem;


### PR DESCRIPTION
Implement pattern-based subscriptions.

Unfortunately, the API surface for subscribing must be changed to facilitate this and future features. Primarily the user must be able to pass options to enable features. For this particular feature it is also very helpful to have access to the event details to determine the exact topic to which the event was published. The broker provides a lot of other useful information in the details object as well.

To facilitate easy addition of options which may be implemented in the future there is a `SubscribeOptions` type which acts as a builder for the `WampDict`. I have additionally added the `Clone` derivation to the `Arg` enum to enable this functionality without requiring the user to worry about ownership of references too much. Some validation could probably be added to prevent some user error here, but I feel like this is decent place to start.

I think building upon the changes required to enable other parts of the advanced profile for WAMP should make it easier to implement progressive RPC calls in the future.